### PR TITLE
カートのリロード問題解決

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -172,13 +172,13 @@ export default new Vuex.Store({
 
       for (const orderItem of state.cartList) {
         const toppingArray = new Array<OrderTopping>();
-        for (const item of orderItem._orderToppingList) {
+        for (const topping of orderItem._orderToppingList) {
           toppingArray.push(
             new OrderTopping(
-              item._id,
-              item._toppingId,
-              item._orderItemId,
-              item._topping
+              topping._id,
+              topping._toppingId,
+              topping._orderItemId,
+              topping._topping
             )
           );
         }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,6 +4,7 @@ import { Item } from "@/types/Item";
 import { OrderItem } from "@/types/OrderItem";
 import axios from "axios";
 import createPersistedState from "vuex-persistedstate";
+import { OrderTopping } from "@/types/OrderTopping";
 
 Vue.use(Vuex);
 
@@ -167,7 +168,43 @@ export default new Vuex.Store({
      * @returns カートの商品情報
      */
     getCartList(state) {
-      return state.cartList;
+      const array = new Array<OrderItem>();
+
+      for (const orderItem of state.cartList) {
+        const toppingArray = new Array<OrderTopping>();
+        for (const item of orderItem._orderToppingList) {
+          toppingArray.push(
+            new OrderTopping(
+              item._id,
+              item._toppingId,
+              item._orderItemId,
+              item._topping
+            )
+          );
+        }
+        array.push(
+          new OrderItem(
+            orderItem._id,
+            orderItem._itemId,
+            orderItem._orderId,
+            orderItem._quantity,
+            orderItem._size,
+            new Item(
+              orderItem._item._id,
+              orderItem._item._type,
+              orderItem._item._name,
+              orderItem._item._description,
+              orderItem._item._priceM,
+              orderItem._item._priceL,
+              orderItem._item._imagePath,
+              orderItem._item._deleted,
+              orderItem._item._toppingList
+            ),
+            toppingArray
+          )
+        );
+      }
+      return array;
     },
 
     /**
@@ -186,7 +223,7 @@ export default new Vuex.Store({
       // ストレージの種類を指定
       storage: window.sessionStorage,
       // isLoginフラグのみセッションストレージに格納しブラウザ更新しても残るようにしている(ログイン時:true / ログアウト時:false)
-      paths: ["isLogin"],
+      paths: ["isLogin", "cartList"],
     }),
   ],
 });

--- a/src/types/Item.ts
+++ b/src/types/Item.ts
@@ -6,23 +6,23 @@ import { Topping } from "./Topping";
 export class Item {
   constructor(
     // ID
-    private _id: number,
+    public _id: number,
     // タイプ
-    private _type: string,
+    public _type: string,
     // 名前
-    private _name: string,
+    public _name: string,
     // 説明
-    private _description: string,
+    public _description: string,
     // Mの価格
-    private _priceM: number,
+    public _priceM: number,
     // Lの価格
-    private _priceL: number,
+    public _priceL: number,
     // 画像パス
-    private _imagePath: string,
+    public _imagePath: string,
     // 削除フラグ
-    private _deleted: boolean,
+    public _deleted: boolean,
     // トッピングリスト
-    private _toppingList: Array<Topping>
+    public _toppingList: Array<Topping>
   ) {}
 
   public get id(): number {

--- a/src/types/OrderItem.ts
+++ b/src/types/OrderItem.ts
@@ -7,19 +7,19 @@ import { OrderTopping } from "./OrderTopping";
 export class OrderItem {
   constructor(
     // ID
-    private _id: number,
+    public _id: number,
     // 商品ID
-    private _itemId: number,
+    public _itemId: number,
     // 注文ID
-    private _orderId: number,
+    public _orderId: number,
     // 数量
-    private _quantity: number,
+    public _quantity: number,
     // サイズ
-    private _size: string,
+    public _size: string,
     // 商品
-    private _item: Item,
+    public _item: Item,
     // 注文トッピングリスト
-    private _orderToppingList: Array<OrderTopping>
+    public _orderToppingList: Array<OrderTopping>
   ) {}
 
   public get id(): number {
@@ -82,8 +82,8 @@ export class OrderItem {
     console.log("呼ばれた！！！");
 
     let price = 0;
-    const toppingPriceM = this.orderToppingList[0].topping.priceM;
-    const toppingPriceL = this.orderToppingList[0].topping.priceL;
+    const toppingPriceM = Number(this.orderToppingList[0].topping.priceM);
+    const toppingPriceL = Number(this.orderToppingList[0].topping.priceL);
     if (this.size === "M") {
       price = Number(
         this.item.priceM * this.quantity +
@@ -95,7 +95,8 @@ export class OrderItem {
           toppingPriceL * this.orderToppingList.length
       );
     }
-    console.log("price:" + price);
+    console.log("toppingPriceM" + toppingPriceM);
+    console.log("length" + this.orderToppingList.length);
 
     return price;
   }

--- a/src/types/OrderTopping.ts
+++ b/src/types/OrderTopping.ts
@@ -5,13 +5,14 @@ import { Topping } from "./Topping";
 export class OrderTopping {
   constructor(
     //ID
-    private _id: number,
+
+    public _id: number,
     //トッピングID
-    private _toppingId: number,
+    public _toppingId: number,
     //注文商品ID
-    private _orderItemId: number,
+    public _orderItemId: number,
     //トッピング
-    private _topping: Topping
+    public _topping: Topping
   ) {}
 
   public get id(): number {

--- a/src/types/Topping.ts
+++ b/src/types/Topping.ts
@@ -4,15 +4,15 @@
 export class Topping {
   constructor(
     // ID
-    private _id: number,
+    public _id: number,
     // タイプ
-    private _type: string,
+    public _type: string,
     // 名前
-    private _name: string,
+    public _name: string,
     // Mの価格
-    private _priceM: number,
+    public _priceM: number,
     // Lの価格
-    private _priceL: number
+    public _priceL: number
   ) {}
 
   public get id(): number {

--- a/src/views/cartList.vue
+++ b/src/views/cartList.vue
@@ -24,23 +24,25 @@
               </td>
               <td v-if="cartItem.size === 'M'">
                 <span class="price">&nbsp;{{ cartItem.size }}</span
-                >&nbsp;&nbsp;{{ cartItem.item.priceM.toLocaleString() }}円
-                &nbsp;&nbsp;{{ cartItem.quantity }}個
+                >&nbsp;&nbsp;{{ cartItem.item.priceM }}円 &nbsp;&nbsp;{{
+                  cartItem.quantity
+                }}個
               </td>
               <td v-if="cartItem.size === 'L'">
                 <span class="price">&nbsp;{{ cartItem.size }}</span
-                >&nbsp;&nbsp;{{ cartItem.item.priceL.toLocaleString() }}円
-                &nbsp;&nbsp;{{ cartItem.quantity }}個
+                >&nbsp;&nbsp;{{ cartItem.item.priceL }}円 &nbsp;&nbsp;{{
+                  cartItem.quantity
+                }}個
               </td>
               <div
                 v-for="orderTopping of cartItem.orderToppingList"
-                v-bind:key="orderTopping.id"
+                v-bind:key="orderTopping._id"
               >
                 <td>
                   <ul>
                     <li v-if="cartItem.size === 'M'">
-                      {{ orderTopping.topping.name }}&emsp;{{
-                        orderTopping.topping.priceM
+                      {{ orderTopping._topping.name }}&emsp;{{
+                        orderTopping._topping.priceM
                       }}円
                     </li>
                     <li v-if="cartItem.size === 'L'">
@@ -113,6 +115,7 @@ export default class CartList extends Vue {
    */
   created(): void {
     this.cartList = this["$store"].getters.getCartList;
+
     // this.cartList = [
     //   //消すこと！！！
     //   new OrderItem(

--- a/src/views/orderConfirm.vue
+++ b/src/views/orderConfirm.vue
@@ -726,9 +726,7 @@ export default class OrderConfirm extends Vue {
     const response = await axios.post(
       "http://153.127.48.168:8080/sample-credit-card-web-api/credit-card/payment ",
       {
-        user_id: 1111,
-        // user_id: Number(this["$store"].getters.getUserId),
-        //★注文一覧をstoreのindexに置いたらそこから取得する↓
+        user_id: this["$store"].getters.getUserId,
         order_number: 12345678901234, //注文番号
         amount: Number(this.taxIncludePrice), //決済金額
         card_number: Number(this.creditNumber), //クレジットカード番号

--- a/src/views/registerAdmin.vue
+++ b/src/views/registerAdmin.vue
@@ -45,7 +45,7 @@
               <span class="error">{{ errorOfZipCode }}</span>
               <input id="zipcode" type="text" maxlength="8" v-model="zipCode" />
               <label for="zipcode">郵便番号(ハイフンあり)</label>
-              <button class="btn" type="button">
+              <button class="btn" type="button" v-on:click="getAddress">
                 <span>住所検索</span>
               </button>
             </div>
@@ -241,6 +241,38 @@ export default class RegisterAdmin extends Vue {
       this.errorMessage = response.data.message;
     } else {
       throw new Error("予期しないエラーが発生しました");
+    }
+  }
+
+  /**
+   * 郵便番号から住所を取得.
+   */
+  async getAddress(): Promise<void> {
+    //初期値リセット(住所、住所エラー)
+    this.address = "";
+    this.errorOfAddress = "";
+    //郵便番号から住所を取得APIに郵便番号を送る
+    try {
+      // const axios = require("axios");
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const axiosJsonpAdapter = require("axios-jsonp");
+
+      const response = await axios.get("https://zipcoda.net/api", {
+        adapter: axiosJsonpAdapter,
+        params: {
+          zipcode: this.zipCode,
+        },
+      });
+      //成功したら住所に取得したデータを代入
+      if (response.data.length === 1) {
+        this.address =
+          response.data.items[0].state_name + response.data.items[0].address;
+        //失敗したらエラーを出す
+      } else {
+        this.errorOfAddress = "住所が見つかりません";
+      }
+    } catch (e) {
+      this.errorOfAddress = "住所が見つかりません";
     }
   }
 


### PR DESCRIPTION
・会員登録時に郵便番号から住所検索できるようにしました
・カートの内容をリロードしても保持できるようにしました
・ログインＩＤを受け取って注文時にAPIで送れるようにしました。